### PR TITLE
Patch 1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,4 +5,4 @@ import { namespace } from '~/src/dsl'
 import { destroy, get, head, patch, post, put, route } from '~/src/dsl/http'
 import { resources } from '~/src/dsl/resources'
 
-export const flauta = { register, resolve, namespace, destroy, get, head, patch, post, put, route, resources }
+export default { register, resolve, namespace, destroy, get, head, patch, post, put, route, resources }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 /* @flow */
 
-export { register, resolve } from '~/src/router'
-export { namespace } from '~/src/dsl'
-export { destroy, get, head, patch, post, put, route } from '~/src/dsl/http'
-export { resources } from '~/src/dsl/resources'
+import { register, resolve } from '~/src/router'
+import { namespace } from '~/src/dsl'
+import { destroy, get, head, patch, post, put, route } from '~/src/dsl/http'
+import { resources } from '~/src/dsl/resources'
+
+export const flauta = { register, resolve, namespace, destroy, get, head, patch, post, put, route, resources }


### PR DESCRIPTION
```
import x from 'y' is shorthand for import { default as x } from 'y'. If a module has no export named default, `import x from 'y'` will return `undefined`.
```

-fixes #2 